### PR TITLE
Allow multiline ternary

### DIFF
--- a/PhpCodeSniffer/Bolt/ruleset-cloned.xml
+++ b/PhpCodeSniffer/Bolt/ruleset-cloned.xml
@@ -68,7 +68,11 @@
     <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing"/>-->
 
     <!-- Verifies that operators have valid spacing surrounding them. -->
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
 
     <!-- ##### PHP ################################################################################################# -->
 

--- a/PhpCodeSniffer/Bolt/ruleset.xml
+++ b/PhpCodeSniffer/Bolt/ruleset.xml
@@ -68,7 +68,11 @@
     <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing"/>-->
 
     <!-- Verifies that operators have valid spacing surrounding them. -->
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
 
     <!-- ##### PHP ################################################################################################# -->
 


### PR DESCRIPTION
Now allowed:

``` php
$foo = $probably
    ? 'yes'
    : 'no';
```
