### PR TITLE
If exclude is missing cs won't validate against the rule following

### DIFF
--- a/PhpCodeSniffer/Bolt/ruleset.xml
+++ b/PhpCodeSniffer/Bolt/ruleset.xml
@@ -28,6 +28,7 @@
         <!-- Not now -->
         <exclude name="Symfony2.Commenting.ClassComment"/>
         <exclude name="Symfony2.Commenting.FunctionComment"/>
+        <exclude name="Squiz.Strings.ConcatenationSpacing"/>
     </rule>
 
     <!-- We use one space instead and allow newlines -->


### PR DESCRIPTION
Without this exclude CS is no regard for the `"Squiz.Strings.ConcatenationSpacing"` rule in PhpStorm. That's tricked me so far... Has it leaded out accidentally before or has it any known reason? 
