### PR TITLE
Side effects fixes and updates

### DIFF
--- a/Bolt/Sniffs/Files/SideEffectsSniff.php
+++ b/Bolt/Sniffs/Files/SideEffectsSniff.php
@@ -16,32 +16,53 @@ class SideEffectsSniff implements Sniff
     {
         $tokens = $file->getTokens();
 
+        $start = 0;
+        while (true) {
+            list($symbolIndex, $effectIndex) = $this->searchForConflict($file, $start, $file->numTokens - 1, $tokens);
+
+            if ($symbolIndex === null || $effectIndex === null) {
+                $file->recordMetric($stackPtr, 'Declarations and side effects mixed', 'no');
+
+                // Ignore the rest of the file.
+                return $file->numTokens + 1;
+            }
+
+            $start = $file->findEndOfStatement($effectIndex) + 1;
+
+            $symbol = $tokens[$symbolIndex];
+            $effect = $tokens[$effectIndex];
+
+            // If line is ignored, try again at next statement
+            if (isset($file->getIgnoredLines()[$effect['line']])) {
+                continue;
+            }
+
+            // If effect is allowed, try again at next statement
+            if ($effect['code'] === T_STRING && in_array($effect['content'], ['Deprecated', 'trigger_error'])) {
+                $start = $file->findEndOfStatement($effectIndex) + 1;
+                continue;
+            }
+
+            $error = 'A file should declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it should execute logic with side effects, but should not do both. The first symbol is defined on line %s and the first side effect is on line %s.';
+            $data = [
+                $symbol['line'],
+                $effect['line'],
+            ];
+            $file->addWarning($error, $effectIndex, 'FoundWithSymbols', $data);
+            $file->recordMetric($stackPtr, 'Declarations and side effects mixed', 'yes');
+
+            return $start;
+        }
+    }
+
+    protected function searchForConflict(File $file, $start, $end, $tokens)
+    {
         $sniff = new \PHP_CodeSniffer\Standards\PSR1\Sniffs\Files\SideEffectsSniff();
         $ref = new \ReflectionMethod($sniff, 'searchForConflict');
         $ref->setAccessible(true);
-        $result = $ref->invoke($sniff, $file, 0, ($file->numTokens - 1), $tokens);
 
-        if ($result['symbol'] !== null && $result['effect'] !== null) {
-            $error = 'A file should declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it should execute logic with side effects, but should not do both. The first symbol is defined on line %s and the first side effect is on line %s.';
-            $data = [
-                $tokens[$result['symbol']]['line'],
-                $tokens[$result['effect']]['line'],
-            ];
+        $result = $ref->invoke($sniff, $file, $start, $end, $tokens);
 
-            //----- Modified from parent (allow calls to "Deprecated" and "trigger_error") --------
-            $effect = $tokens[$result['effect']];
-            if ($effect['code'] === T_STRING && in_array($effect['content'], ['Deprecated', 'trigger_error'])) {
-                return $file->numTokens + 1;
-            }
-            //----- end modification --------
-
-            $file->addWarning($error, $result['effect'], 'FoundWithSymbols', $data);
-            $file->recordMetric($stackPtr, 'Declarations and side effects mixed', 'yes');
-        } else {
-            $file->recordMetric($stackPtr, 'Declarations and side effects mixed', 'no');
-        }
-
-        // Ignore the rest of the file.
-        return ($file->numTokens + 1);
+        return [$result['symbol'], $result['effect']];
     }
 }

--- a/Bolt/Sniffs/Files/SideEffectsSniff.php
+++ b/Bolt/Sniffs/Files/SideEffectsSniff.php
@@ -10,6 +10,12 @@ class SideEffectsSniff implements Sniff
     public $allowed = [
         'Deprecated',
         'trigger_error',
+
+        // Used for BC handling
+        'class_alias',
+        'class_exists',
+        'trait_exists',
+        'interface_exists',
     ];
 
     public function register()

--- a/Bolt/Sniffs/Files/SideEffectsSniff.php
+++ b/Bolt/Sniffs/Files/SideEffectsSniff.php
@@ -7,6 +7,11 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class SideEffectsSniff implements Sniff
 {
+    public $allowed = [
+        'Deprecated',
+        'trigger_error',
+    ];
+
     public function register()
     {
         return [T_OPEN_TAG];
@@ -38,7 +43,7 @@ class SideEffectsSniff implements Sniff
             }
 
             // If effect is allowed, try again at next statement
-            if ($effect['code'] === T_STRING && in_array($effect['content'], ['Deprecated', 'trigger_error'])) {
+            if ($effect['code'] === T_STRING && in_array($effect['content'], $this->allowed)) {
                 $start = $file->findEndOfStatement($effectIndex) + 1;
                 continue;
             }

--- a/Bolt/Sniffs/Files/SideEffectsSniff.php
+++ b/Bolt/Sniffs/Files/SideEffectsSniff.php
@@ -35,7 +35,7 @@ class SideEffectsSniff implements Sniff
             }
             //----- end modification --------
 
-            $file->addWarning($error, 0, 'FoundWithSymbols', $data);
+            $file->addWarning($error, $result['effect'], 'FoundWithSymbols', $data);
             $file->recordMetric($stackPtr, 'Declarations and side effects mixed', 'yes');
         } else {
             $file->recordMetric($stackPtr, 'Declarations and side effects mixed', 'no');

--- a/Bolt/Tests/Files/SideEffectsUnitTest.deprecated.inc
+++ b/Bolt/Tests/Files/SideEffectsUnitTest.deprecated.inc
@@ -1,5 +1,0 @@
-<?php
-
-Deprecated::warn();
-
-function zzzzzz() {}

--- a/Bolt/Tests/Files/SideEffectsUnitTest.inc
+++ b/Bolt/Tests/Files/SideEffectsUnitTest.inc
@@ -1,5 +1,7 @@
 <?php
 
+// @codingStandardsIgnoreLine
+zzzzzz();
 zzzzzz();
 
 function zzzzzz() {}

--- a/Bolt/Tests/Files/SideEffectsUnitTest.inc
+++ b/Bolt/Tests/Files/SideEffectsUnitTest.inc
@@ -1,7 +1,10 @@
 <?php
 
+Deprecated::warn();
+trigger_error();
 // @codingStandardsIgnoreLine
 zzzzzz();
-zzzzzz();
+zzzzzz(); // error
+zzzzzz(); // not error because error was already found
 
 function zzzzzz() {}

--- a/Bolt/Tests/Files/SideEffectsUnitTest.php
+++ b/Bolt/Tests/Files/SideEffectsUnitTest.php
@@ -8,12 +8,8 @@ class SideEffectsUnitTest extends AbstractSniffTestCase
 {
     protected function getWarningList($filename = null)
     {
-        if ($filename === 'SideEffectsUnitTest.inc') {
-            return [
-                5 => 1,
-            ];
-        }
-
-        return [];
+        return [
+            7 => 1,
+        ];
     }
 }

--- a/Bolt/Tests/Files/SideEffectsUnitTest.php
+++ b/Bolt/Tests/Files/SideEffectsUnitTest.php
@@ -10,7 +10,7 @@ class SideEffectsUnitTest extends AbstractSniffTestCase
     {
         if ($filename === 'SideEffectsUnitTest.inc') {
             return [
-                1 => 1,
+                5 => 1,
             ];
         }
 

--- a/Bolt/Tests/Files/SideEffectsUnitTest.trigger_error.inc
+++ b/Bolt/Tests/Files/SideEffectsUnitTest.trigger_error.inc
@@ -1,5 +1,0 @@
-<?php
-
-trigger_error();
-
-function zzzzzz() {}


### PR DESCRIPTION
- Changed reported warning to the line the side effect is on - this way it can be ignored by line
- Fixed logic to continue searching for a side effect after hitting an allowed one or an ignored line
- Made `allowed` "function calls" (string token values) configurable
- Allowing `class_alias` and `class/trait/interface_exists` functions since these are used for BC handling. The former is really a definition instead of a side effect anyways and the latter just invokes the autoloader.