### PR TITLE
Update friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.6",
+        "friendsofphp/php-cs-fixer": "^2.10",
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^3.0"
     },

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -32,14 +32,15 @@ class Rules implements \IteratorAggregate, RiskyRulesAwareInterface
         'yoda_style'                  => ['equal' => false, 'identical' => false],
 
         // Add additional rules
-        'array_syntax'                => ['syntax' => 'short'],
-        'heredoc_to_nowdoc'           => true,
-        'linebreak_after_opening_tag' => true,
-        'no_useless_else'             => true,
-        'no_useless_return'           => true,
-        'ordered_imports'             => true,
-        'phpdoc_order'                => true,
-        'single_line_comment_style'   => ['comment_types' => ['hash']],
+        'array_syntax'                           => ['syntax' => 'short'],
+        'heredoc_to_nowdoc'                      => true,
+        'linebreak_after_opening_tag'            => true,
+        'no_useless_else'                        => true,
+        'no_useless_return'                      => true,
+        'multiline_whitespace_before_semicolons' => ['strategy' => 'new_line_for_chained_calls'],
+        'ordered_imports'                        => true,
+        'phpdoc_order'                           => true,
+        'single_line_comment_style'              => ['comment_types' => ['hash']],
     ];
 
     private $riskyRules = [


### PR DESCRIPTION
- Bump requirement to 2.10
- Add 'multiline_whitespace_before_semicolons' => ['strategy' => 'new_line_for_chained_calls']